### PR TITLE
feat: add Drift chat to /pricing contact us

### DIFF
--- a/_includes/default.footer.html
+++ b/_includes/default.footer.html
@@ -156,3 +156,55 @@
     }
   }
 </script>
+
+{% if page.pricing == "true" %}
+<script>
+
+  // Asynchronous version of Drift installation snippet in order to optimize performances
+  "use strict";
+
+  function loadDriftWidget() {
+    var t = window.driftt = window.drift = window.driftt || [];
+    if (!t.init) {
+      if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
+      t.invoked = !0, t.methods = ["identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on"],
+        t.factory = function (e) {
+          return function () {
+            var n = Array.prototype.slice.call(arguments);
+            return n.unshift(e), t.push(n), t;
+          };
+        }, t.methods.forEach(function (e) {
+          t[e] = t.factory(e);
+        }), t.load = function (t) {
+          var e = 3e5, n = Math.ceil(new Date() / e) * e, o = document.createElement("script");
+          o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + n + "/" + t + ".js";
+          var i = document.getElementsByTagName("script")[0];
+          i.parentNode.insertBefore(o, i);
+        };
+    }
+    drift.SNIPPET_VERSION = '0.3.1';
+    drift.load('wh3bg2vtun24');
+    drift.on('ready', function (api) {
+      //Hide Drift chat via css, because the API hide() method is slower and the icon blinks for a moment before disappearing
+      $('.drift-frame-chat').css('display', 'none')
+      $('.drift-widget-controller').css('display', 'none')
+      //api.widget.hide()
+    })
+  };
+
+  // Show Drift icon and conversation modal function
+  function showDriftWidget() {
+    $('.drift-frame-chat').css('display', '')
+    $('.drift-widget-controller').css('display', '')
+    drift.api.openChat();
+  }
+
+  // Load Drift after everything else is loaded
+  $(window).on('load', function () { loadDriftWidget() });
+
+  // Show Drift if visitor stays more than one minute on page
+  setTimeout(function () { showDriftWidget() }, 60 * 1000);
+
+</script>
+
+{% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -42,3 +42,36 @@
       }
   }
 </script>
+
+{% if page.pricing == "true" %}
+
+<script>
+
+    "use strict";
+
+    function LoadDriftWidget() {
+        var t = window.driftt = window.drift = window.driftt || [];
+        if (!t.init) {
+            if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
+            t.invoked = !0, t.methods = ["identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on"],
+                t.factory = function (e) {
+                    return function () {
+                        var n = Array.prototype.slice.call(arguments);
+                        return n.unshift(e), t.push(n), t;
+                    };
+                }, t.methods.forEach(function (e) {
+                    t[e] = t.factory(e);
+                }), t.load = function (t) {
+                    var e = 3e5, n = Math.ceil(new Date() / e) * e, o = document.createElement("script");
+                    o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + n + "/" + t + ".js";
+                    var i = document.getElementsByTagName("script")[0];
+                    i.parentNode.insertBefore(o, i);
+                };
+        }
+        drift.SNIPPET_VERSION = '0.3.1';
+        drift.load('wh3bg2vtun24');
+    };
+
+</script>
+
+{% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -42,36 +42,3 @@
       }
   }
 </script>
-
-{% if page.pricing == "true" %}
-
-<script>
-
-    "use strict";
-
-    function LoadDriftWidget() {
-        var t = window.driftt = window.drift = window.driftt || [];
-        if (!t.init) {
-            if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
-            t.invoked = !0, t.methods = ["identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on"],
-                t.factory = function (e) {
-                    return function () {
-                        var n = Array.prototype.slice.call(arguments);
-                        return n.unshift(e), t.push(n), t;
-                    };
-                }, t.methods.forEach(function (e) {
-                    t[e] = t.factory(e);
-                }), t.load = function (t) {
-                    var e = 3e5, n = Math.ceil(new Date() / e) * e, o = document.createElement("script");
-                    o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + n + "/" + t + ".js";
-                    var i = document.getElementsByTagName("script")[0];
-                    i.parentNode.insertBefore(o, i);
-                };
-        }
-        drift.SNIPPET_VERSION = '0.3.1';
-        drift.load('wh3bg2vtun24');
-    };
-
-</script>
-
-{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -345,8 +345,8 @@
         var productId = button.data('checkout-product-id')
 
         if (!productId) {
-          window.location.href = "https://support.mailmeteor.com/help/contact-support#contact-us"
           event.preventDefault()
+          LoadDriftWidget()
         } else {
           var modal = $(this)
           modal.find('input.checkout-plan-id').val(productId)

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -346,7 +346,7 @@
 
         if (!productId) {
           event.preventDefault()
-          LoadDriftWidget()
+          showDriftWidget()
         } else {
           var modal = $(this)
           modal.find('input.checkout-plan-id').val(productId)

--- a/pricing.html
+++ b/pricing.html
@@ -11,6 +11,7 @@ og_url: https://mailmeteor.com/pricing
 
 stripe: "popover"
 redirect_from: "/launch/deuxio"
+pricing: "true"
 ---
 
 <!-- PRICING TABLE  -->


### PR DESCRIPTION

## Fonctionnement
- Dans le```<head>```, si la page est pricing(paramètres jekyll```pricing=true```), on ajoute le script de Drift
- Ce script lance la fonction LoadDriftWidget au clic sur Contact us(plans enterprise > 50 users)

## Frictions:
- Drift est trop lent à s'éxécuter au clic sur Contact us (1 à 3 secondes)
- Trouver le moyen de faire cohabiter l'apparition du pop up au bout d'un setTimeout et le déclenchement forcé lors d'un clic sur Contact us