### PR TITLE
Feat/pricing faq

### DIFF
--- a/_data/faqs.yml
+++ b/_data/faqs.yml
@@ -1,90 +1,4 @@
 #
-# FAQ entries
-#
-
-entries:
-  - question: Does Mailmeteor offer a free trial?
-    answer: You can enjoy Mailmeteor for free with up to **75 emails a day**. It's more free email quota compared to what you can find in other mail merge solutions. Whenever you want to send more emails, Mailmeteor Premium includes up to 1500 emails, real-time tracking, scheduling, attachments or email alias support. If you want to benefit from premium features, you can upgrade your account on our [paid plans](/pricing).
-
-  - question: How many emails can I send with Mailmeteor?
-    answer: >
-      Mailmeteor Premium allows you to send personalized emails up to the limits imposed by Gmail:
-
-        - Google Workspace (formerly G Suite) accounts can send up to 1,500 emails per day
-        - Gmail accounts (@gmail.com) can send up to 500 emails per day
-
-      Mailmeteor abides by these limits and allows you to send as many emails as you can using your own Gmail account. Your quota varies depending on the type of your Google account (G Suite or Gmail) and your plan. Read more about [email quota](https://support.mailmeteor.com/introduction/quick-start/email-quota).
-
-  - question: How is Mailmeteor different from other mailing solutions?
-    answer: >
-      Mailmeteor lets you send email campaigns from your Gmail inbox, contrary to email marketing softwares, like Mailchimp or Sendgrid. Emails sent with Mailmeteor look as if you typed them manually for each contact. It means **better email deliverability, less spams and way better opening rates**!
-
-
-      You can also compare Mailmeteor to other mail merge extensions for Gmail - like [Yet another mail merge](/alternative/yetanothermailmerge) or [Gmass](/alternative/gmass).
-
-
-      Mailmeteor is different in 3 ways:
-
-        1. **The best rated Google add-on**. Your mail merge experience is made effortless, no computer skills are required.
-        2. **Designed to respect your privacy**. Mailmeteor has no access to your Gmail inbox, contrary to other add-ons that ask for read access to your Gmail inbox and Google Drive files.
-        3. **Affordable pricing options**. Mailmeteor has a generous free plan and a [simple pricing](/pricing) that works at any scale.
-
-  - question: How can I ensure that my emails won’t go to spam?
-    answer: Mailmeteor sends emails directly from your Gmail account and adds a sending delay between each email sent. These mechanisms prevent your emails falling into spam folders. In addition, we strongly recommend you to read our [guidelines to maximize email deliverability](https://support.mailmeteor.com/introduction/sending-guidelines) before sending large volumes of emails.
-
-  - question: How can I personalize my emails?
-    answer: >
-      You can personalize every part of the email, from subject line to email body, as well as CC/BCC fields. The only limit is your imagination! 
-
-      Imagine having a “firstname” column in your spreadsheet, adding "Hi {{firstname}}" in your email will be automatically replaced by your recipient’s first name ("Hi Sally" for example).You just need to put your variables inside double brackets {{ }}
-
-      Here are some examples:
-        - Personalized email subject: {{ Mutual connection }} recommended we talk
-        - Personalized greetings and recipients: Hello {{ firstname }}
-        - Personalized content, custom links, postscriptum...
-
-      Emails sent with Mailmeteor look as if you typed them manually for each of your recipients.
-
-  - question: How does Mailmeteor keep my data safe?
-    answer: >
-      By design, your data stays at all times on your Google Spreadsheet. Here's all the data we need in order to make Mailmeteor work:
-        - Your email address to identify your account
-        - If you are a paying customer, your name to identify payment
-        - Campaigns sent metadata (number of emails, date of sending, sheet's name, *that's all*)
-        - Emails sent metadata (date of sending, opens and clicks events, *that's all again*)
-
-      Mailmeteor complies with the French Data Protection Laws and the European General Data Protection Regulation 2016/679 (GDPR). You have a right of access, correction and removal of your personal data which you may exercise by sending us an email at [privacy@mailmeteor.com](mailto:privacy@mailmeteor.com).
-
-  - question: How to add CC or BCC recipients?
-    answer: Sure you can. Add a column in your sheet with "cc" or "bcc" as header. Then, add emails in the cells. If you have several recipients in CC or BCC, separate emails with commas. Here is a [video tutorial](https://www.youtube.com/watch?v=3me-iWYFSY0).
-
-  - question: Is Mailmeteor suitable for working in teams?
-    answer: Sure! [Mailmeteor’s Enterprise licenses](/pricing) allow users to collaborate on the same document and access the email tracking report of campaigns. Large companies, organizations and academic institutions trust Mailmeteor for their email needs.
-
-  - question: What CRMs does Mailmeteor integrate with?
-    answer: You can use Mailmeteor with your favorite CRM tool, like Salesforce or Hubspot. To log emails sent with Mailmeteor, you will need to find your unique BCC address provided by your CRM. You will put this address as a BCC recipient when sending emails from Mailmeteor. Here is a [guide to help you use Mailmeteor with your CRM](https://support.mailmeteor.com/introduction/advanced/crm-integration).
-
-  - question: How do I manage my subscription?
-    answer: >
-      To manage your account, open a Google spreadsheet, **go to the "Add-ons" menu, then select "Mailmeteor" > "My account"**.
-
-
-      To cancel your account, click on “Cancel”. Follow the instructions and the subscription will be cancelled immediately afterward. If you cancel before the end of your subscription period, you will still be able to use your Mailmeteor premium account (up to the last day of the subscription).
-
-  - question: I need help with Mailmeteor
-    answer: >
-      Need help with Mailmeteor? You may find answers to your questions in our [Help Center](https://support.mailmeteor.com/).
-
-
-      Also you can [contact us](https://support.mailmeteor.com/help/contact-support), we'll be glad to help! Our team speaks English, French or Spanish. We are located in Paris, France. Our timezone is the Central European Summer Time zone.
-
-
-      We may take a few hours to answer your message depending on the time of the day. Usually we answer right away or under 24 hours.
-
-  - question: Can I send emails from space?
-    answer: Mailmeteor works anywhere you can access the internet, so technically you should be able to send emails from space. If you manage to do it, please send us a picture!
-
-#
 # FAQ pricing
 #
 
@@ -115,7 +29,7 @@ billing:
       To cancel your account, click on “Cancel”. Follow the instructions and the subscription will be cancelled immediately afterward. If you cancel before the end of your subscription period, you will still be able to use your Mailmeteor premium account (up to the last day of the subscription).
 
   - question: Is it possible to transfer my license to a different Gmail or Google Workspace account?
-    answer: If you need to change ownership of your license, that’s no problem! Please contact us and we’ll proceed with the change.
+    answer: Of course! If you need to change ownership of your license, please [contact us](https://support.mailmeteor.com/help/contact-support) and we’ll proceed with the change.
 
 security:
   - question: How does Mailmeteor keep my data safe?
@@ -130,9 +44,11 @@ security:
 
   - question: What permissions are needed to use Mailmeteor?
     answer: >
+
       Mailmeteor only requests permissions to send emails and does not require access to your email data, contrary to other mail merge add-ons. This means Mailmeteor cannot read, modify or delete your emails by design. For that reason, Mailmeteor is considered to be the safest mail merge solution for Gmail. 
 
-      You can find here [the exhaustive list of permissions requested by Mailmeteor and their meaning](https://support.mailmeteor.com/help/privacy).
+
+      You can find here the exhaustive [list of permissions requested by Mailmeteor](https://support.mailmeteor.com/help/privacy) and their meaning.
 
 deliverability:
   - question: How is Mailmeteor different from other mailing solutions?
@@ -164,13 +80,15 @@ deliverability:
 features:
   - question: How can I personalize my emails?
     answer: >
-      You can personalize every part of the email, from subject line to email body, as well as CC/BCC fields. The only limit is your imagination! 
+      You can personalize every part of the email, from subject line to email body, as well as CC/BCC fields. The only limit is your imagination!
 
-      Imagine having a “firstname” column in your spreadsheet, adding "Hi {{firstname}}" in your email will be automatically replaced by your recipient’s first name ("Hi Sally" for example).You just need to put your variables inside double brackets {{ }}
+
+      Imagine having a “firstname” column in your spreadsheet, adding *"Hi {{firstname}}"* in your email will be automatically replaced by your recipient’s first name (*"Hi Sally"* for example).You just need to put your variables inside double brackets, like this → {{ }}
+
 
       Here are some examples:
-        - Personalized email subject: {{ Mutual connection }} recommended we talk
-        - Personalized greetings and recipients: Hello {{ firstname }}
+        - Personalized email subject: *{{ Mutual connection }} recommended we talk*
+        - Personalized greetings and recipients: *Hello {{ firstname }}*
         - Personalized content, custom links, postscriptum...
 
       Emails sent with Mailmeteor look as if you typed them manually for each of your recipients.

--- a/_data/faqs.yml
+++ b/_data/faqs.yml
@@ -84,4 +84,116 @@ entries:
   - question: Can I send emails from space?
     answer: Mailmeteor works anywhere you can access the internet, so technically you should be able to send emails from space. If you manage to do it, please send us a picture!
 
+#
+# FAQ pricing
+#
+
+billing:
+  - question: Does Mailmeteor offer a free trial?
+    answer: You can enjoy Mailmeteor for free with up to **75 emails a day**. It's more free email quota compared to what you can find in other mail merge solutions. Whenever you want to send more emails, Mailmeteor Premium includes up to 1500 emails, real-time tracking, scheduling, attachments or email alias support. If you want to benefit from premium features, you can upgrade your account on our [paid plans](/pricing).
+
+  - question: How can I pay?
+    answer: >
+
+      - **By credit card:** We accept most major debit or credit cards (Visa, MasterCard, Maestro, American Express, Discover, JCB, Diners Club, China Union, Apple Pay and Google Pay). Our payments are secured by Stripe, one of the largest payment providers in the world.
+
+      - **By wire transfers:** It is possible to pay through wire transfer or SEPA transfer for larger transactions (over $500). Depending on your location and preferences, we can accept transfers to our US bank account or European bank account.
+
+      - **By PayPal:** If you’d like to use PayPal, [contact us](/sales) and we’ll send you a secure invoice.
+
+  - question: Can I get a quote and send a purchase order?
+    answer: We accept purchase orders and send quotes for orders of more than $500.
+
+  - question: Do you offer plans for bigger organizations?
+    answer: Sure! If you need more than 50 users, please [contact us](/sales) here and we'll get back to you under 24h. Maillmeteor scales with your organization. For example, our largest customer has 100,000 employees using Mailmeteor.
+
+  - question: How do I manage my subscription?
+    answer: >
+      To manage your account, open a Google spreadsheet, **go to the "Add-ons" menu, then select "Mailmeteor" > "My account"**.
+
+
+      To cancel your account, click on “Cancel”. Follow the instructions and the subscription will be cancelled immediately afterward. If you cancel before the end of your subscription period, you will still be able to use your Mailmeteor premium account (up to the last day of the subscription).
+
+  - question: Is it possible to transfer my license to a different Gmail or Google Workspace account?
+    answer: If you need to change ownership of your license, that’s no problem! Please contact us and we’ll proceed with the change.
+
+security:
+  - question: How does Mailmeteor keep my data safe?
+    answer: >
+      By design, your data stays at all times on your Google Spreadsheet. Here's all the data we need in order to make Mailmeteor work:
+        - Your email address to identify your account
+        - If you are a paying customer, your name to identify payment
+        - Campaigns sent metadata (number of emails, date of sending, sheet's name, *that's all*)
+        - Emails sent metadata (date of sending, opens and clicks events, *that's all again*)
+
+      Mailmeteor complies with the French Data Protection Laws and the European General Data Protection Regulation 2016/679 (GDPR). You have a right of access, correction and removal of your personal data which you may exercise by sending us an email at [privacy@mailmeteor.com](mailto:privacy@mailmeteor.com).
+
+  - question: What permissions are needed to use Mailmeteor?
+    answer: >
+      Mailmeteor only requests permissions to send emails and does not require access to your email data, contrary to other mail merge add-ons. This means Mailmeteor cannot read, modify or delete your emails by design. For that reason, Mailmeteor is considered to be the safest mail merge solution for Gmail. 
+
+      You can find here [the exhaustive list of permissions requested by Mailmeteor and their meaning](https://support.mailmeteor.com/help/privacy).
+
+deliverability:
+  - question: How is Mailmeteor different from other mailing solutions?
+    answer: >
+      Mailmeteor lets you send email campaigns from your Gmail inbox, contrary to email marketing softwares, like Mailchimp or Sendgrid. Emails sent with Mailmeteor look as if you typed them manually for each contact. It means **better email deliverability, less spams and way better opening rates**!
+
+
+      You can also compare Mailmeteor to other mail merge extensions for Gmail - like [Yet another mail merge](/alternative/yetanothermailmerge) or [Gmass](/alternative/gmass).
+
+
+      Mailmeteor is different in 3 ways:
+
+        1. **The best rated Google add-on**. Your mail merge experience is made effortless, no computer skills are required.
+        2. **Designed to respect your privacy**. Mailmeteor has no access to your Gmail inbox, contrary to other add-ons that ask for read access to your Gmail inbox and Google Drive files.
+        3. **Affordable pricing options**. Mailmeteor has a generous free plan and a [simple pricing](/pricing) that works at any scale.
+
+  - question: How many emails can I send with Mailmeteor?
+    answer: >
+      Mailmeteor Premium allows you to send personalized emails up to the limits imposed by Gmail:
+
+        - Google Workspace (formerly G Suite) accounts can send up to 1,500 emails per day
+        - Gmail accounts (@gmail.com) can send up to 500 emails per day
+
+      Mailmeteor abides by these limits and allows you to send as many emails as you can using your own Gmail account. Your quota varies depending on the type of your Google account (G Suite or Gmail) and your plan. Read more about [email quota](https://support.mailmeteor.com/introduction/quick-start/email-quota).
+
+  - question: How can I ensure that my emails won’t go to spam?
+    answer: Mailmeteor sends emails directly from your Gmail account and adds a sending delay between each email sent. These mechanisms prevent your emails falling into spam folders. In addition, we strongly recommend you to read our [guidelines to maximize email deliverability](https://support.mailmeteor.com/introduction/sending-guidelines) before sending large volumes of emails.
+
+features:
+  - question: How can I personalize my emails?
+    answer: >
+      You can personalize every part of the email, from subject line to email body, as well as CC/BCC fields. The only limit is your imagination! 
+
+      Imagine having a “firstname” column in your spreadsheet, adding "Hi {{firstname}}" in your email will be automatically replaced by your recipient’s first name ("Hi Sally" for example).You just need to put your variables inside double brackets {{ }}
+
+      Here are some examples:
+        - Personalized email subject: {{ Mutual connection }} recommended we talk
+        - Personalized greetings and recipients: Hello {{ firstname }}
+        - Personalized content, custom links, postscriptum...
+
+      Emails sent with Mailmeteor look as if you typed them manually for each of your recipients.
+
+  - question: How to add CC or BCC recipients?
+    answer: Sure you can. Add a column in your sheet with "cc" or "bcc" as header. Then, add emails in the cells. If you have several recipients in CC or BCC, separate emails with commas. Here is a [video tutorial](https://www.youtube.com/watch?v=3me-iWYFSY0).
+
+  - question: Is Mailmeteor suitable for working in teams?
+    answer: Sure! [Mailmeteor’s Enterprise licenses](/pricing) allow users to collaborate on the same document and access the email tracking report of campaigns. Large companies, organizations and academic institutions trust Mailmeteor for their email needs.
+
+  - question: What CRMs does Mailmeteor integrate with?
+    answer: You can use Mailmeteor with your favorite CRM tool, like Salesforce or Hubspot. To log emails sent with Mailmeteor, you will need to find your unique BCC address provided by your CRM. You will put this address as a BCC recipient when sending emails from Mailmeteor. Here is a [guide to help you use Mailmeteor with your CRM](https://support.mailmeteor.com/introduction/advanced/crm-integration).
+
+help:
+  - question: I need help with Mailmeteor
+    answer: >
+      Need help with Mailmeteor? You may find answers to your questions in our [Help Center](https://support.mailmeteor.com/).
+
+
+      Also you can [contact us](https://support.mailmeteor.com/help/contact-support), we'll be glad to help! Our team speaks English, French or Spanish. We are located in Paris, France. Our timezone is the Central European Summer Time zone.
+
+
+      We may take a few hours to answer your message depending on the time of the day. Usually we answer right away or under 24 hours.
+
+  - question: Can I send emails from space?
     answer: Mailmeteor works anywhere you can access the internet, so technically you should be able to send emails from space. If you manage to do it, please send us a picture!

--- a/_data/faqs.yml
+++ b/_data/faqs.yml
@@ -1,4 +1,90 @@
 #
+# FAQ entries
+#
+
+entries:
+  - question: Is there a free trial?
+    answer: You can enjoy Mailmeteor for free with up to **75 emails a day**. It's more free email quota compared to what you can find in other mail merge solutions. Whenever you want to send more emails, Mailmeteor Premium includes up to 1500 emails, real-time tracking, scheduling, attachments or email alias support. If you want to benefit from premium features, you can upgrade your account on our [paid plans](/pricing).
+
+  - question: How many emails can I send with Mailmeteor?
+    answer: >
+      Mailmeteor Premium allows you to send personalized emails up to the limits imposed by Gmail:
+
+        - Google Workspace (formerly G Suite) accounts can send up to 1,500 emails per day
+        - Gmail accounts (@gmail.com) can send up to 500 emails per day
+
+      Mailmeteor abides by these limits and allows you to send as many emails as you can using your own Gmail account. Your quota varies depending on the type of your Google account (G Suite or Gmail) and your plan. Read more about [email quota](https://support.mailmeteor.com/introduction/quick-start/email-quota).
+
+  - question: How is Mailmeteor different from other mailing solutions?
+    answer: >
+      Mailmeteor lets you send email campaigns from your Gmail inbox, contrary to email marketing softwares, like Mailchimp or Sendgrid. Emails sent with Mailmeteor look as if you typed them manually for each contact. It means **better email deliverability, less spams and way better opening rates**!
+
+
+      You can also compare Mailmeteor to other mail merge extensions for Gmail - like [Yet another mail merge](/alternative/yetanothermailmerge) or [Gmass](/alternative/gmass).
+
+
+      Mailmeteor is different in 3 ways:
+
+        1. **The best rated Google add-on**. Your mail merge experience is made effortless, no computer skills are required.
+        2. **Designed to respect your privacy**. Mailmeteor has no access to your Gmail inbox, contrary to other add-ons that ask for read access to your Gmail inbox and Google Drive files.
+        3. **Affordable pricing options**. Mailmeteor has a generous free plan and a [simple pricing](/pricing) that works at any scale.
+
+  - question: How can I ensure that my emails won’t go to spam?
+    answer: Mailmeteor sends emails directly from your Gmail account and adds a sending delay between each email sent. These mechanisms prevent your emails falling into spam folders. In addition, we strongly recommend you to read our [guidelines to maximize email deliverability](https://support.mailmeteor.com/introduction/sending-guidelines) before sending large volumes of emails.
+
+  - question: How can I personalize my emails?
+    answer: >
+      You can personalize every part of the email, from subject line to email body, as well as CC/BCC fields. The only limit is your imagination! 
+
+      Imagine having a “firstname” column in your spreadsheet, adding "Hi {{firstname}}" in your email will be automatically replaced by your recipient’s first name ("Hi Sally" for example).You just need to put your variables inside double brackets {{ }}
+
+      Here are some examples:
+        - Personalized email subject: {{ Mutual connection }} recommended we talk
+        - Personalized greetings and recipients: Hello {{ firstname }}
+        - Personalized content, custom links, postscriptum...
+
+      Emails sent with Mailmeteor look as if you typed them manually for each of your recipients.
+
+  - question: How does Mailmeteor keep my data safe?
+    answer: >
+      By design, your data stays at all times on your Google Spreadsheet. Here's all the data we need in order to make Mailmeteor work:
+        - Your email address to identify your account
+        - If you are a paying customer, your name to identify payment
+        - Campaigns sent metadata (number of emails, date of sending, sheet's name, *that's all*)
+        - Emails sent metadata (date of sending, opens and clicks events, *that's all again*)
+
+      Mailmeteor complies with the French Data Protection Laws and the European General Data Protection Regulation 2016/679 (GDPR). You have a right of access, correction and removal of your personal data which you may exercise by sending us an email at [privacy@mailmeteor.com](mailto:privacy@mailmeteor.com).
+
+  - question: How to add CC or BCC recipients?
+    answer: Sure you can. Add a column in your sheet with "cc" or "bcc" as header. Then, add emails in the cells. If you have several recipients in CC or BCC, separate emails with commas. Here is a [video tutorial](https://www.youtube.com/watch?v=3me-iWYFSY0).
+
+  - question: Is Mailmeteor suitable for working in teams?
+    answer: Sure! [Mailmeteor’s Enterprise licenses](/pricing) allow users to collaborate on the same document and access the email tracking report of campaigns. Large companies, organizations and academic institutions trust Mailmeteor for their email needs.
+
+  - question: What CRMs does Mailmeteor integrate with?
+    answer: You can use Mailmeteor with your favorite CRM tool, like Salesforce or Hubspot. To log emails sent with Mailmeteor, you will need to find your unique BCC address provided by your CRM. You will put this address as a BCC recipient when sending emails from Mailmeteor. Here is a [guide to help you use Mailmeteor with your CRM](https://support.mailmeteor.com/introduction/advanced/crm-integration).
+
+  - question: How do I manage my subscription?
+    answer: >
+      To manage your account, open a Google spreadsheet, **go to the "Add-ons" menu, then select "Mailmeteor" > "My account"**.
+
+
+      To cancel your account, click on “Cancel”. Follow the instructions and the subscription will be cancelled immediately afterward. If you cancel before the end of your subscription period, you will still be able to use your Mailmeteor premium account (up to the last day of the subscription).
+
+  - question: I need help with Mailmeteor
+    answer: >
+      Need help with Mailmeteor? You may find answers to your questions in our [Help Center](https://support.mailmeteor.com/).
+
+
+      Also you can [contact us](https://support.mailmeteor.com/help/contact-support), we'll be glad to help! Our team speaks English, French or Spanish. We are located in Paris, France. Our timezone is the Central European Summer Time zone.
+
+
+      We may take a few hours to answer your message depending on the time of the day. Usually we answer right away or under 24 hours.
+
+  - question: Can I send emails from space?
+    answer: Mailmeteor works anywhere you can access the internet, so technically you should be able to send emails from space. If you manage to do it, please send us a picture!
+
+#
 # FAQ pricing
 #
 

--- a/_data/faqs.yml
+++ b/_data/faqs.yml
@@ -59,17 +59,17 @@ entries:
     answer: Sure you can. Add a column in your sheet with "cc" or "bcc" as header. Then, add emails in the cells. If you have several recipients in CC or BCC, separate emails with commas. Here is a [video tutorial](https://www.youtube.com/watch?v=3me-iWYFSY0).
 
   - question: Is Mailmeteor suitable for working in teams?
-    answer: Sure! [Mailmeteor’s Enterprise licenses](/pricing) allow users to collaborate on the same document and access the email tracking report of campaigns. Large companies, organizations and academic institutions trust Mailmeteor for their email needs.
+    answer: Sure! [Mailmeteor Enterprise](/sales) allows teams to collaborate on the same document and access the email tracking report of campaigns. Large companies, organizations and academic institutions trust Mailmeteor for their email needs. Our largest customer has 100,000 employees using Mailmeteor.
 
   - question: What CRMs does Mailmeteor integrate with?
     answer: You can use Mailmeteor with your favorite CRM tool, like Salesforce or Hubspot. To log emails sent with Mailmeteor, you will need to find your unique BCC address provided by your CRM. You will put this address as a BCC recipient when sending emails from Mailmeteor. Here is a [guide to help you use Mailmeteor with your CRM](https://support.mailmeteor.com/introduction/advanced/crm-integration).
 
   - question: How do I manage my subscription?
     answer: >
-      To manage your account, open a Google spreadsheet, **go to the "Add-ons" menu, then select "Mailmeteor" > "My account"**.
+      To manage your account, [access your settings from Mailmeteor's dashboard](https://dashboard.mailmeteor.com/account).
 
 
-      To cancel your account, click on “Cancel”. Follow the instructions and the subscription will be cancelled immediately afterward. If you cancel before the end of your subscription period, you will still be able to use your Mailmeteor premium account (up to the last day of the subscription).
+      To cancel your account, on the same page click on “Cancel” within your account profile. Follow the instructions and the subscription will be cancelled immediately afterward. If you cancel before the end of your subscription period, you will still be able to use your Mailmeteor premium account (up to the last day of the subscription).
 
   - question: I need help with Mailmeteor
     answer: >
@@ -109,10 +109,10 @@ billing:
 
   - question: How do I manage my subscription?
     answer: >
-      To manage your account, open a Google spreadsheet, **go to the "Add-ons" menu, then select "Mailmeteor" > "My account"**.
+      To manage your account, [access your settings from Mailmeteor's dashboard](https://dashboard.mailmeteor.com/account).
 
 
-      To cancel your account, click on “Cancel”. Follow the instructions and the subscription will be cancelled immediately afterward. If you cancel before the end of your subscription period, you will still be able to use your Mailmeteor premium account (up to the last day of the subscription).
+      To cancel your account, on the same page click on “Cancel”. Follow the instructions and the subscription will be cancelled immediately afterward. If you cancel before the end of your subscription period, you will still be able to use your Mailmeteor premium account (up to the last day of the subscription).
 
   - question: Is it possible to transfer my license to a different Gmail or Google Workspace account?
     answer: Of course! If you need to change ownership of your license, please [contact us](https://support.mailmeteor.com/help/contact-support) and we’ll proceed with the change.
@@ -169,7 +169,7 @@ features:
       You can personalize every part of the email, from subject line to email body, as well as CC/BCC fields. The only limit is your imagination!
 
 
-      Imagine having a “firstname” column in your spreadsheet, adding *"Hi {{firstname}}"* in your email will be automatically replaced by your recipient’s first name (*"Hi Sally"* for example).You just need to put your variables inside double brackets, like this → {{ }}
+      Imagine having a “firstname” column in your spreadsheet, adding *"Hi {{firstname}}"* in your email will be automatically replaced by your recipient’s first name (*"Hi Sally"* for example). You just need to put your variables inside double brackets, like this → {{ }}
 
 
       Here are some examples:
@@ -180,10 +180,10 @@ features:
       Emails sent with Mailmeteor look as if you typed them manually for each of your recipients.
 
   - question: How to add CC or BCC recipients?
-    answer: Sure you can. Add a column in your sheet with "cc" or "bcc" as header. Then, add emails in the cells. If you have several recipients in CC or BCC, separate emails with commas. Here is a [video tutorial](https://www.youtube.com/watch?v=3me-iWYFSY0).
+    answer: That's really easy. In your spreadsheet, add a column with "cc" (and/or "bcc") as header. Then, add emails in the cells. Mailmeteo will add those recipients in CC (or BCC). If you have several recipients in CC or BCC, separate emails with commas. Here is a [video tutorial](https://www.youtube.com/watch?v=3me-iWYFSY0).
 
   - question: Is Mailmeteor suitable for working in teams?
-    answer: Sure! [Mailmeteor’s Enterprise licenses](/pricing) allow users to collaborate on the same document and access the email tracking report of campaigns. Large companies, organizations and academic institutions trust Mailmeteor for their email needs.
+    answer: Sure! [Mailmeteor Enterprise](/sales) allows teams to collaborate on the same document and access the email tracking report of campaigns. Large companies, organizations and academic institutions trust Mailmeteor for their email needs. Our largest customer has 100,000 employees using Mailmeteor.
 
   - question: What CRMs does Mailmeteor integrate with?
     answer: You can use Mailmeteor with your favorite CRM tool, like Salesforce or Hubspot. To log emails sent with Mailmeteor, you will need to find your unique BCC address provided by your CRM. You will put this address as a BCC recipient when sending emails from Mailmeteor. Here is a [guide to help you use Mailmeteor with your CRM](https://support.mailmeteor.com/introduction/advanced/crm-integration).

--- a/_data/faqs.yml
+++ b/_data/faqs.yml
@@ -3,7 +3,7 @@
 #
 
 entries:
-  - question: Does Mailmeteor have a free trial?
+  - question: Does Mailmeteor offer a free trial?
     answer: You can enjoy Mailmeteor for free with up to **75 emails a day**. It's more free email quota compared to what you can find in other mail merge solutions. Whenever you want to send more emails, Mailmeteor Premium includes up to 1500 emails, real-time tracking, scheduling, attachments or email alias support. If you want to benefit from premium features, you can upgrade your account on our [paid plans](/pricing).
 
   - question: How many emails can I send with Mailmeteor?
@@ -12,7 +12,7 @@ entries:
 
         - Google Workspace (formerly G Suite) accounts can send up to 1,500 emails per day
         - Gmail accounts (@gmail.com) can send up to 500 emails per day
-      
+
       Mailmeteor abides by these limits and allows you to send as many emails as you can using your own Gmail account. Your quota varies depending on the type of your Google account (G Suite or Gmail) and your plan. Read more about [email quota](https://support.mailmeteor.com/introduction/quick-start/email-quota).
 
   - question: How is Mailmeteor different from other mailing solutions?
@@ -28,17 +28,19 @@ entries:
         1. **The best rated Google add-on**. Your mail merge experience is made effortless, no computer skills are required.
         2. **Designed to respect your privacy**. Mailmeteor has no access to your Gmail inbox, contrary to other add-ons that ask for read access to your Gmail inbox and Google Drive files.
         3. **Affordable pricing options**. Mailmeteor has a generous free plan and a [simple pricing](/pricing) that works at any scale.
-      
 
   - question: How can I ensure that my emails won’t go to spam?
     answer: Mailmeteor sends emails directly from your Gmail account and adds a sending delay between each email sent. These mechanisms prevent your emails falling into spam folders. In addition, we strongly recommend you to read our [guidelines to maximize email deliverability](https://support.mailmeteor.com/introduction/sending-guidelines) before sending large volumes of emails.
 
-  - question: To what extent can I personalize my emails?
+  - question: How can I personalize my emails?
     answer: >
-      You can personalize every part of the email, from subject line to content. The only limit is your imagination! Somes examples:
+      You can personalize every part of the email, from subject line to email body, as well as CC/BCC fields. The only limit is your imagination! 
 
-        - Personalized email subject
-        - Personalized greetings and recipients
+      Imagine having a “firstname” column in your spreadsheet, adding "Hi {{firstname}}" in your email will be automatically replaced by your recipient’s first name ("Hi Sally" for example).You just need to put your variables inside double brackets {{ }}
+
+      Here are some examples:
+        - Personalized email subject: {{ Mutual connection }} recommended we talk
+        - Personalized greetings and recipients: Hello {{ firstname }}
         - Personalized content, custom links, postscriptum...
 
       Emails sent with Mailmeteor look as if you typed them manually for each of your recipients.
@@ -50,19 +52,19 @@ entries:
         - If you are a paying customer, your name to identify payment
         - Campaigns sent metadata (number of emails, date of sending, sheet's name, *that's all*)
         - Emails sent metadata (date of sending, opens and clicks events, *that's all again*)
-      
+
       Mailmeteor complies with the French Data Protection Laws and the European General Data Protection Regulation 2016/679 (GDPR). You have a right of access, correction and removal of your personal data which you may exercise by sending us an email at [privacy@mailmeteor.com](mailto:privacy@mailmeteor.com).
 
   - question: How to add CC or BCC recipients?
     answer: Sure you can. Add a column in your sheet with "cc" or "bcc" as header. Then, add emails in the cells. If you have several recipients in CC or BCC, separate emails with commas. Here is a [video tutorial](https://www.youtube.com/watch?v=3me-iWYFSY0).
 
-  - question: Is Mailmeteor suitable for working in teams? 
+  - question: Is Mailmeteor suitable for working in teams?
     answer: Sure! [Mailmeteor’s Enterprise licenses](/pricing) allow users to collaborate on the same document and access the email tracking report of campaigns. Large companies, organizations and academic institutions trust Mailmeteor for their email needs.
 
   - question: What CRMs does Mailmeteor integrate with?
     answer: You can use Mailmeteor with your favorite CRM tool, like Salesforce or Hubspot. To log emails sent with Mailmeteor, you will need to find your unique BCC address provided by your CRM. You will put this address as a BCC recipient when sending emails from Mailmeteor. Here is a [guide to help you use Mailmeteor with your CRM](https://support.mailmeteor.com/introduction/advanced/crm-integration).
 
-  - question: How to manage my subscription?
+  - question: How do I manage my subscription?
     answer: >
       To manage your account, open a Google spreadsheet, **go to the "Add-ons" menu, then select "Mailmeteor" > "My account"**.
 
@@ -78,6 +80,8 @@ entries:
 
 
       We may take a few hours to answer your message depending on the time of the day. Usually we answer right away or under 24 hours.
-  
-  - question: Can I send email from space?
+
+  - question: Can I send emails from space?
+    answer: Mailmeteor works anywhere you can access the internet, so technically you should be able to send emails from space. If you manage to do it, please send us a picture!
+
     answer: Mailmeteor works anywhere you can access the internet, so technically you should be able to send emails from space. If you manage to do it, please send us a picture!

--- a/_includes/faq-pricing.html
+++ b/_includes/faq-pricing.html
@@ -1,0 +1,102 @@
+<!-- FAQs  -->
+<section class="faq" data-aos="fade-up" data-aos-delay="200" data-aos-duration="800" data-aos-easing="ease-out">
+	<div class="container">
+		<h2 id="faq" class="text-center">Questions & answers</h2>
+		<p class="text-center">Find tutorials & help guides in our <a href="https://support.mailmeteor.com/" target="_blank" rel="noopener">documentation</a>.</p>
+		<div id="accordion-billing" class="accordions">
+			{% assign i = 0 %}
+			<h3>Billing</h3>
+			{% for entry in site.data.faqs.billing %}
+			<div class="card">
+				<div class="card-header accordionpointer collapsed" id="heading{{i}}" data-toggle="collapse" data-target="#collapse{{i}}">
+					<p class="mb-0" aria-expanded="true" aria-controls="collapse{{i}}">{{entry.question}}</p>
+					<span class="faq-expander"></span>
+				</div>
+
+				<div id="collapse{{i}}" class="collapse" aria-labelledby="heading{{i}}" data-parent="#accordion-billing">
+					<div class="card-body">
+						{{entry.answer | markdownify}}
+					</div>
+				</div>
+			</div>
+			{% assign i = i | plus:1 %}
+			{% endfor %}
+		</div>
+		<div id="accordion-security" class="accordions">
+			<h3>Security & Privacy</h3>
+			{% for entry in site.data.faqs.security  %}
+			<div class="card">
+				<div class="card-header accordionpointer collapsed" id="heading{{i}}" data-toggle="collapse" data-target="#collapse{{i}}">
+					<p class="mb-0" aria-expanded="true" aria-controls="collapse{{i}}">{{entry.question}}</p>
+					<span class="faq-expander"></span>
+				</div>
+
+				<div id="collapse{{i}}" class="collapse" aria-labelledby="heading{{i}}" data-parent="#accordion-security">
+					<div class="card-body">
+						{{entry.answer | markdownify}}
+					</div>
+				</div>
+			</div>
+			{% assign i = i | plus:1 %}
+			{% endfor %}
+		</div>
+		<div id="accordion-deliverability" class="accordions">
+			<h3>Email deliverability</h3>
+			{% for entry in site.data.faqs.deliverability %}
+			<div class="card">
+				<div class="card-header accordionpointer collapsed" id="heading{{i}}" data-toggle="collapse" data-target="#collapse{{i}}">
+					<p class="mb-0" aria-expanded="true" aria-controls="collapse{{i}}">{{entry.question}}</p>
+					<span class="faq-expander"></span>
+				</div>
+
+				<div id="collapse{{i}}" class="collapse" aria-labelledby="heading{{i}}" data-parent="#accordion-deliverability">
+					<div class="card-body">
+						{{entry.answer | markdownify}}
+					</div>
+				</div>
+			</div>
+			{% assign i = i | plus:1 %}
+			{% endfor %}
+		</div>
+		<div id="accordion-features" class="accordions">
+			<h3>Features</h3>
+			{% for entry in site.data.faqs.features %}
+			<div class="card">
+				<div class="card-header accordionpointer collapsed" id="heading{{i}}" data-toggle="collapse" data-target="#collapse{{i}}">
+					<p class="mb-0" aria-expanded="true" aria-controls="collapse{{i}}">{{entry.question}}</p>
+					<span class="faq-expander"></span>
+				</div>
+
+				<div id="collapse{{i}}" class="collapse" aria-labelledby="heading{{i}}" data-parent="#accordion-features">
+					<div class="card-body">
+						{{entry.answer | markdownify}}
+					</div>
+				</div>
+			</div>
+			{% assign i = i | plus:1 %}
+			{% endfor %}
+		</div>
+		<div id="accordion-help" class="accordions">
+			<h3>Help</h3>
+			{% for entry in site.data.faqs.help %}
+			<div class="card">
+				<div class="card-header accordionpointer collapsed" id="heading{{i}}" data-toggle="collapse" data-target="#collapse{{i}}">
+					<p class="mb-0" aria-expanded="true" aria-controls="collapse{{i}}">{{entry.question}}</p>
+					<span class="faq-expander"></span>
+				</div>
+
+				<div id="collapse{{i}}" class="collapse" aria-labelledby="heading{{i}}" data-parent="#accordion-help">
+					<div class="card-body">
+						{{entry.answer | markdownify}}
+					</div>
+				</div>
+			</div>
+			{% assign i = i | plus:1 %}
+			{% endfor %}
+		</div> 
+		<div class="container d-flex justify-content-center mt-3">
+			<a href="/pricing" class="btn btn-filled mx-2" data-aos="fade-in" data-aos-duration="800" data-aos-easing="ease-out"><span style=font-size:75%>READY FOR TAKE OFF?</span> <br> GET MAILMETEOR → </a>
+		</div>
+	</div>
+
+</section>

--- a/_includes/faq.html
+++ b/_includes/faq.html
@@ -3,7 +3,7 @@
 	<div class="container">
 		<h2 id="faq" class="text-center">Questions & answers</h2>
 		<p class="text-center">Find tutorials & help guides in our <a href="https://support.mailmeteor.com/" target="_blank" rel="noopener">documentation</a>.</p>
-		<div id="accordion">
+		<div class="accordions">
 			{% assign i = 0 %}
 			{% for entry in site.data.faqs.entries %}
 			<div class="card">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1048,7 +1048,7 @@ sup {
   border-bottom: 1px solid rgba(16, 24, 32, 0.05);
 }
 
-.faq #accordion .card-header {
+.faq .accordions .card-header {
   background-color: white;
   border-bottom: 1px solid rgba(16, 24, 32, 0.05);
   padding: 0.55rem;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1076,13 +1076,19 @@ sup {
   cursor: pointer;
 }
 
-.faq #accordion {
+.faq .accordions {
   max-width: 960px;
   margin: auto;
 }
 
-.faq #accordion .card-header {
+.faq .accordions .card-header {
   font-weight: 700;
+}
+
+.faq .accordions h3 {
+  text-transform: uppercase;
+  color: #7da4ff;
+  padding: 2rem 0 0 0;
 }
 
 @media (max-width: 768px) {

--- a/pricing.html
+++ b/pricing.html
@@ -177,7 +177,7 @@ redirect_from: "/launch/deuxio"
 
 {%- include testimonials.html -%}
 {%- include reviews.html -%}
-{%- include faq.html -%}
+{%- include faq-pricing.html -%}
 
 <!-- MODAL FOR INDIVIDUAL PLANS  -->
 <div class="modal fade" id="pricingIndividualModal" tabindex="-1" role="dialog" aria-hidden="true">


### PR DESCRIPTION
# What

Add a dedicated FAQ section to pricing.

# How it works

* New dedicated sections for pricing in faqs.yml (downside: we replicated certain questions)
* Each FAQ pricing sections have a separated <div class="accordions"> (downside: we have several accordions)

# To review

- HTML structure
- Content for typos & additional improvements
- Review structure if we want to have the same kind of FAQ for other pages than /pricing, but with less sections. It would mean we only pick certain sections for other pages and show all for pricing / or re-order sections?

![faq-pricing](https://user-images.githubusercontent.com/46222664/110902451-352b3a80-8306-11eb-9f31-ad2be5fcffdd.gif)
